### PR TITLE
fix: apply getPath to PUBLIC_PATH to allow use with CDN

### DIFF
--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,4 +1,5 @@
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, getPath } from '@edx/frontend-platform';
 
-export const routePath = () => `${getConfig().PUBLIC_PATH}:courseId`;
-export const locationId = () => decodeURIComponent(window.location.pathname).replace(getConfig().PUBLIC_PATH, '');
+const publicPath = getPath(getConfig().PUBLIC_PATH);
+export const routePath = () => `${publicPath}:courseId`;
+export const locationId = () => decodeURIComponent(window.location.pathname).replace(publicPath, '');

--- a/src/data/constants/app.test.js
+++ b/src/data/constants/app.test.js
@@ -6,6 +6,7 @@ jest.unmock('./app');
 jest.mock('@edx/frontend-platform', () => {
   const PUBLIC_PATH = '/test-public-path/';
   return {
+    ...jest.requireActual('@edx/frontend-platform'),
     getConfig: () => ({ PUBLIC_PATH }),
     PUBLIC_PATH,
   };


### PR DESCRIPTION
**Description** 

When ORA is configured to be used with CDN the `locationId` is unresolved because `PUBLIC_PATH` is not fully matched. 

![image](https://github.com/user-attachments/assets/3c1a0a96-b9bf-4eef-a185-ca81f03070f6)


The API returns 404 because the location has `/ora-grading/`.

**How to replicate**

1. Set the public path to a URL, e.g. `ENV PUBLIC_PATH='http://apps.local.edly.io/ora-grading/'` 
2. Load the ORA-Grading MFE
3. Check the request. 