### PR TITLE
fix: fixed public path replacement

### DIFF
--- a/src/data/constants/app.js
+++ b/src/data/constants/app.js
@@ -1,4 +1,5 @@
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, getPath } from '@edx/frontend-platform';
 
-export const routePath = () => `${getConfig().PUBLIC_PATH}:courseId`;
-export const locationId = () => decodeURIComponent(window.location.pathname).replace(getConfig().PUBLIC_PATH, '');
+const publicPath = getPath(getConfig().PUBLIC_PATH);
+export const routePath = () => `${publicPath}:courseId`;
+export const locationId = () => decodeURIComponent(window.location.pathname).replace(publicPath, '');

--- a/src/data/constants/app.test.js
+++ b/src/data/constants/app.test.js
@@ -6,6 +6,7 @@ jest.unmock('./app');
 jest.mock('@edx/frontend-platform', () => {
   const PUBLIC_PATH = '/test-public-path/';
   return {
+    ...jest.requireActual('@edx/frontend-platform'),
     getConfig: () => ({ PUBLIC_PATH }),
     PUBLIC_PATH,
   };


### PR DESCRIPTION
This PR aims to fix the improper path replacement from the ORA MFE to work with CDN.

**How to test**

1. Install this MFE using this branch in a sumac environment you can follow the i[nstallation guide](https://github.com/eduNEXT/frontend-app-ora-grading?tab=readme-ov-file#developing) .
2. Make sure to have a course with an Open Response Assesment and a student user to submit a response.
3. Open your ORA route as an instructor and you should see your dashboard loading correcly:

![Screenshot from 2025-01-30 19-16-37](https://github.com/user-attachments/assets/4fbd9273-7f09-49f8-b981-642459d33a60)
