### PR TITLE
fix: remove import of @edx/brand to can install modern-theming

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,10 +1,6 @@
 // frontend-app-*/src/index.scss
 @use "@openedx/paragon/styles/css/core/custom-media-breakpoints.css" as paragonCustomMediaBreakpoints;
 
-@import "~@edx/brand/paragon/fonts";
-@import "~@edx/brand/paragon/variables";
-@import "~@edx/brand/paragon/overrides";
-
 $input-focus-box-shadow: var(--pgn-elevation-form-input-base); // hack to get upgrade to paragon 4.0.0 to work
 
 @import "~@edx/frontend-component-footer/dist/_footer";

--- a/src/containers/Rubric/Rubric.scss
+++ b/src/containers/Rubric/Rubric.scss
@@ -1,6 +1,3 @@
-@import "~@edx/brand/paragon/variables";
-@import "~@edx/brand/paragon/overrides";
-
 .criteria-label {
   width: 100%;
   .criteria-title {


### PR DESCRIPTION
# Description 
💡Remove unnecessary @edx/brand/paragon SCSS imports when using modern-theming
This PR removes the following SCSS imports from the MFE’s style entry point:

```scss
@import "~@edx/brand/paragon/fonts";
@import "~@edx/brand/paragon/variables";
@import "~@edx/brand/paragon/overrides";
```

# Why
This MFE is configured to use modern-theming, which replaces traditional SASS-based theming with a CSS variables-based approach. In this setup, these SCSS imports are not only unnecessary, but can also cause issues.

# Technical Context
modern-theming leverages design tokens and CSS custom properties instead of SASS variables and overrides.

These imports were previously needed for legacy SASS-based brand overrides, but:

With modern-theming, all theming is applied via the theme.js file and CSS variables.

Keeping these imports introduces resolution errors, particularly when modern-theming is aliased to @edx/brand, since it doesn’t expose those SCSS files.

# Current Issue
The MFE fails to build due to errors resolving SCSS paths like:

```sass
@import "~@edx/brand/paragon/fonts";
```

This happens because @edx/brand is now pointing to modern-theming, which does not provide legacy SCSS files.

# Official Reference
According to the [official Open edX migration guide](https://openedx.atlassian.net/wiki/spaces/BPL/pages/3770744958/Migrating+MFEs+to+Paragon+design+tokens+and+CSS+variables#Remove-all-(almost)-Paragon-imports-from-the-SCSS-entry-point-in-your-MFE), these imports should be removed when migrating an MFE to use design tokens and CSS variables.

> "Remove all (almost) Paragon imports from the SCSS entry point in your MFE..."

# Expected Outcome
Fix build errors related to SCSS resolution.

Clean up unnecessary legacy theming code.

Align the MFE with modern Open edX theming practices.

Reduce confusion and maintenance overhead related to outdated SASS imports.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.